### PR TITLE
[#74] 카드ID 리스트와 카드 상태를 인자로 받고 인자로 받은 상태를 가진 카드 객체들만 추려 카드 객체 리스트를 반환한다

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -1,7 +1,5 @@
 package org.wedding.adapter.in.web;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,7 +21,6 @@ import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.in.usecase.card.ReadCardUseCase;
 import org.wedding.application.service.response.card.ReadCardResponse;
 import org.wedding.common.response.ApiResponse;
-import org.wedding.domain.CardStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -88,15 +85,6 @@ public class CardController {
     public ResponseEntity<ReadCardResponse> readCardByCardTitle(@PathVariable String cardTitle) {
 
         ReadCardResponse response = readCardUseCase.readCardsByCardTitle(cardTitle);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping("/status/{cardStatus}")
-    @Operation(summary = "카드 상태로 조회", description = "카드 상태로 조회")
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<List<ReadCardResponse>> readCardsByCardStatus(@PathVariable CardStatus cardStatus) {
-
-        List<ReadCardResponse> response = readCardUseCase.readCardsByCardStatus(cardStatus);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/org/wedding/adapter/out/persistence/mybatis/MybatisCardRepositoryImpl.java
+++ b/src/main/java/org/wedding/adapter/out/persistence/mybatis/MybatisCardRepositoryImpl.java
@@ -11,27 +11,21 @@ import org.wedding.domain.card.Card;
 @Repository
 @Mapper
 public interface MybatisCardRepositoryImpl extends CardRepository {
+
     @Override
     int save(Card card);
-
     @Override
     void update(Card card);
-
     @Override
     boolean existsByCardTitle(String cardTitle);
-
     @Override
     boolean existsByCardId(int cardId);
-
     @Override
     Card findByCardId(int cardId);
-
     @Override
     Card findByCardTitle(String cardTitle);
-
     @Override
-    List<Card> findByCardStatus(CardStatus cardStatus);
-
+    List<Card> findByCardIdsAndCardStatus(List<Integer> cardIds, CardStatus cardStatus);
     @Override
     void deleteByCardId(int cardId);
 }

--- a/src/main/java/org/wedding/application/port/in/usecase/card/ReadCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/card/ReadCardUseCase.java
@@ -9,7 +9,7 @@ public interface ReadCardUseCase {
 
     ReadCardResponse readCardByCardId(int cardId);
     ReadCardResponse readCardsByCardTitle(String cardTitle);
-    List<ReadCardResponse> readCardsByCardStatus(CardStatus cardStatus);
+    List<ReadCardResponse> readCardsStausByIdsAndStatus(List<Integer> cardIds, CardStatus cardStatus);
 
     // TODO: deadline에 따라 정렬 되는 기능은 캘린더 도메인 구현 후 추가하기
     // TODO: CardBoard 도메인 리팩토링 후 구현하기 (Card는 User를 몰라서 UserId로 찾을 수 없음)

--- a/src/main/java/org/wedding/application/port/out/repository/CardRepository.java
+++ b/src/main/java/org/wedding/application/port/out/repository/CardRepository.java
@@ -6,23 +6,15 @@ import org.wedding.domain.CardStatus;
 import org.wedding.domain.card.Card;
 
 public interface CardRepository {
+
     int save(Card card);
-
     void update(Card card);
-
     boolean existsByCardId(int cardId);
-
     boolean existsByCardTitle(String cardTitle);
-
     Card findByCardId(int cardId);
-
     Card findByCardTitle(String cardTitle);
-
-    List<Card> findByCardStatus(CardStatus cardStatus);
-
+    List<Card> findByCardIdsAndCardStatus(List<Integer> cardIds, CardStatus cardStatus);
     void deleteByCardId(int cardId);
-
     // List<Card> findAll(int cardBoardId); // TODO: 카드보드 리팩토링 후 추가
-
     // List<TodoListPort> findTodoByCardId(int cardId); // TODO: 투두 도메인 리팩토링 후 추가
 }

--- a/src/main/resources/mapper/CardMapper.xml
+++ b/src/main/resources/mapper/CardMapper.xml
@@ -41,15 +41,19 @@
         SELECT * FROM card WHERE card_title = #{cardTitle}
     </select>
 
-    <select id="findByCardStatus" resultType="list" resultMap="cardResultMap">
-        SELECT card_id, card_title, budget, deadline, card_status
-        FROM card
-        WHERE card_status = #{cardStatus}
-    </select>
-
     <select id="findAll" resultType="list" resultMap="cardResultMap">
         SELECT card_id, card_title, budget, deadline, card_status
         FROM card
+    </select>
+    
+    <select id="findByCardIdsAndCardStatus" resultType="list" resultMap="cardResultMap">
+        SELECT card_id, card_title, budget, deadline, card_status
+        FROM card
+        WHERE card_id IN
+        <foreach collection="cardIds" item="cardId" open="(" separator="," close=")">
+            #{cardId}
+        </foreach>
+        AND card_status = #{cardStatus}
     </select>
 
     <delete id="deleteByCardId" parameterType="int">


### PR DESCRIPTION
### Isuue Number:
#74 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 기존에는 카드 상태만 인자로 받아서 모든 카드를 대상으로 추렸다면 카드ID 리스트를 함께 받는 로직으로 수정한다.

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 이렇게 수정한 이유는 카드 조회시 인증이 필요해지면서, 특정 유저의 카드 목록만 조회하는 기능이 필요했기 때문이다.
- 카드와 유저는 서로의 존재를 모르기 때문에, 카드ID리스트는 카드보드에서 전달해 줄 것이다.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.