### PR TITLE
[#73] 카드 상태별 조회 기능 구현

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
@@ -1,0 +1,55 @@
+package org.wedding.adapter.in.web;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.wedding.adapter.out.dto.CardsResponse;
+import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
+import org.wedding.application.service.response.cardboard.CardInfo;
+import org.wedding.domain.CardStatus;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name="CardBoard API", description = "유저와 카드를 연결하는 카드보드 API")
+@RestController
+@RequestMapping("/api/v1/cardboard")
+@RequiredArgsConstructor
+public class CardBoardController {
+
+    private final CardBoardUseCase cardBoardUseCase;
+
+    @GetMapping("/{cardStatus}")
+    @Operation(summary = "카드 상태별 조회" , description = "카드 상태별 조회")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<List<CardsResponse>> readCardsByStatus(@PathVariable CardStatus cardStatus) {
+        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        ReadCardCommand command = new ReadCardCommand(userId, cardStatus);
+        List<CardInfo> cardInfos = cardBoardUseCase.readCardsByStatus(command);
+        List<CardsResponse> response = new ArrayList<>();
+        for (CardInfo cardInfo : cardInfos) {
+            response.add(
+                new CardsResponse(
+                    cardInfo.cardId(),
+                    cardInfo.cardTitle(),
+                    cardInfo.budget(),
+                    cardInfo.deadline(),
+                    cardInfo.cardStatus()
+                ));
+        }
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -2,6 +2,7 @@ package org.wedding.adapter.in.web;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,7 +25,6 @@ import org.wedding.common.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,9 +44,9 @@ public class CardController {
     @PostMapping()
     @Operation(summary = "카드 생성", description = "카드 생성")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<ApiResponse<Void>> createCard(@RequestBody @Valid CreateCardRequest cardRequest, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> createCard(@RequestBody @Valid CreateCardRequest cardRequest) {
 
-        int userId = (int) request.getAttribute("userId");
+        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         CreateCardCommand command = new CreateCardCommand(userId, cardRequest.cardTitle(), cardRequest.budget(), cardRequest.deadline());
 
         createCardUseCase.createCard(command);

--- a/src/main/java/org/wedding/adapter/in/web/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/wedding/adapter/in/web/security/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package org.wedding.adapter.in.web.security;
 
 import java.io.IOException;
+import java.util.Collections;
 
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -32,7 +34,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && JwtUtils.validateToken(token)) {
             int userId = JwtUtils.getUserIdFromToken(token);
-            request.setAttribute("userId", userId);
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userId, null, Collections.emptyList());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);
         } else {
             SecurityContextHolder.clearContext();

--- a/src/main/java/org/wedding/adapter/out/dto/CardsResponse.java
+++ b/src/main/java/org/wedding/adapter/out/dto/CardsResponse.java
@@ -1,0 +1,14 @@
+package org.wedding.adapter.out.dto;
+
+import java.time.LocalDate;
+
+import org.wedding.domain.CardStatus;
+
+public record CardsResponse(
+    int cardId,
+    String cardTitle,
+    Long budget,
+    LocalDate deadline,
+    CardStatus cardStatus
+) {
+}

--- a/src/main/java/org/wedding/adapter/out/persistence/mybatis/MybatisCardBoardRepositoryImpl.java
+++ b/src/main/java/org/wedding/adapter/out/persistence/mybatis/MybatisCardBoardRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.wedding.adapter.out.persistence.mybatis;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 import org.wedding.application.port.out.repository.CardBoardRepository;
@@ -15,4 +17,6 @@ public interface MybatisCardBoardRepositoryImpl extends CardBoardRepository {
     void addCardIds(int cardBoardId, int cardId);
     @Override
     CardBoard findCardBoardByUserId(int userId);
+    @Override
+    List<Integer> findCardIdsByUserId(int userId);
 }

--- a/src/main/java/org/wedding/application/port/in/CardBoardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/CardBoardUseCase.java
@@ -1,8 +1,13 @@
 package org.wedding.application.port.in;
 
+import java.util.List;
+
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
+import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
+import org.wedding.application.service.response.cardboard.CardInfo;
 
 public interface CardBoardUseCase {
     void createCardBoard(CreateCardBoardCommand command);
     void addCardToCardBoard(int cardId, int userId);
+    List<CardInfo> readCardsByStatus(ReadCardCommand command);
 }

--- a/src/main/java/org/wedding/application/port/in/command/cardboard/ReadCardCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/cardboard/ReadCardCommand.java
@@ -1,0 +1,19 @@
+package org.wedding.application.port.in.command.cardboard;
+
+import org.wedding.domain.CardStatus;
+
+public record ReadCardCommand (
+    int userId,
+    CardStatus cardStatus
+) {
+
+    @Override
+    public String toString() {
+        return """
+            ReadCardCommand{
+                userId='%s',
+                cardStatus='%s'
+            }
+            """.formatted(userId, cardStatus);
+    }
+}

--- a/src/main/java/org/wedding/application/port/out/repository/CardBoardRepository.java
+++ b/src/main/java/org/wedding/application/port/out/repository/CardBoardRepository.java
@@ -1,5 +1,7 @@
 package org.wedding.application.port.out.repository;
 
+import java.util.List;
+
 import org.wedding.domain.cardboard.CardBoard;
 
 public interface CardBoardRepository {
@@ -7,4 +9,5 @@ public interface CardBoardRepository {
     int save(CardBoard cardBoard);
     void addCardIds(int cardBoardId, int cardId);
     CardBoard findCardBoardByUserId(int userId);
+    List<Integer> findCardIdsByUserId(int userId);
 }

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -1,12 +1,24 @@
 package org.wedding.application.service;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.wedding.application.port.in.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
+import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
+import org.wedding.application.port.in.usecase.card.ReadCardUseCase;
 import org.wedding.application.port.out.repository.CardBoardRepository;
+import org.wedding.application.service.response.card.ReadCardResponse;
+import org.wedding.application.service.response.cardboard.CardInfo;
 import org.wedding.domain.cardboard.CardBoard;
 import org.wedding.domain.cardboard.exception.CardBoardError;
 import org.wedding.domain.cardboard.exception.CardBoardException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
 
@@ -15,6 +27,7 @@ import lombok.AllArgsConstructor;
 public class CardBoardService implements CardBoardUseCase {
 
     private final CardBoardRepository cardBoardRepository;
+    private final ReadCardUseCase readCardUseCase;
 
     @Override
     public void createCardBoard(CreateCardBoardCommand command) {
@@ -22,6 +35,7 @@ public class CardBoardService implements CardBoardUseCase {
         cardBoardRepository.save(cardBoard);
     }
 
+    @Transactional
     @Override
     public void addCardToCardBoard(int cardId, int userId) {
         CardBoard cardBoard = cardBoardRepository.findCardBoardByUserId(userId);
@@ -30,5 +44,44 @@ public class CardBoardService implements CardBoardUseCase {
         }
         cardBoard.addCard(cardId);
         cardBoardRepository.addCardIds(cardBoard.getCardBoardId(), cardId);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<CardInfo> readCardsByStatus(ReadCardCommand command) {
+        String cardIdsStr = cardBoardRepository
+            .findCardIdsByUserId(command.userId())
+            .toString().replaceFirst("\\[", "").replaceFirst("]", "");
+
+        List<Integer> cardIds = convertStringToList(cardIdsStr);
+
+        List<ReadCardResponse> cardResponses =
+            readCardUseCase.readCardsStausByIdsAndStatus(cardIds, command.cardStatus());
+        return toCardBoardCardInfo(cardResponses);
+    }
+
+    private List<CardInfo> toCardBoardCardInfo(List<ReadCardResponse> cardResponses) {
+        List<CardInfo> cardInfos = new ArrayList<>();
+        for (ReadCardResponse cardResponse : cardResponses) {
+            cardInfos.add(
+                new CardInfo(
+                    cardResponse.cardId(),
+                    cardResponse.cardTitle(),
+                    cardResponse.budget(),
+                    cardResponse.deadline(),
+                    cardResponse.cardStatus()
+                ));
+        }
+        return cardInfos;
+    }
+
+    public List<Integer> convertStringToList(String numberListStr) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(numberListStr, new TypeReference<>() {
+            });
+        } catch (IOException e) {
+            throw new RuntimeException("CardIds로 리스트 변환이 실패했습니다.", e);
+        }
     }
 }

--- a/src/main/java/org/wedding/application/service/response/cardboard/CardInfo.java
+++ b/src/main/java/org/wedding/application/service/response/cardboard/CardInfo.java
@@ -1,0 +1,14 @@
+package org.wedding.application.service.response.cardboard;
+
+import java.time.LocalDate;
+
+import org.wedding.domain.CardStatus;
+
+public record CardInfo(
+    int cardId,
+    String cardTitle,
+    Long budget,
+    LocalDate deadline,
+    CardStatus cardStatus
+) {
+}

--- a/src/main/java/org/wedding/config/CorsConfig.java
+++ b/src/main/java/org/wedding/config/CorsConfig.java
@@ -11,6 +11,6 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOrigins("*")
-            .allowedMethods("GET", "POST", "PUT", "DELETE");
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "FETCH");
     }
 }

--- a/src/main/java/org/wedding/domain/card/event/CardCreatedEvent.java
+++ b/src/main/java/org/wedding/domain/card/event/CardCreatedEvent.java
@@ -9,7 +9,7 @@ public class CardCreatedEvent extends ApplicationEvent {
     private final int cardId;
     private final int userId;
 
-    public CardCreatedEvent(int userId, int cardId) {
+    public CardCreatedEvent(int cardId, int userId) {
         super(cardId);
         this.cardId = cardId;
         this.userId = userId;

--- a/src/main/resources/mapper/CardBoardMapper.xml
+++ b/src/main/resources/mapper/CardBoardMapper.xml
@@ -10,12 +10,20 @@
         <result column="card_ids" property="cardIds" javaType="List" typeHandler="org.wedding.adapter.out.persistence.mybatis.JsonTypeHandler"/>
     </resultMap>
 
+    <resultMap id="CardIdsResultMap" type="string">
+        <result column="card_ids" typeHandler="org.wedding.adapter.out.persistence.mybatis.JsonTypeHandler"/>
+    </resultMap>
+
     <insert id="save" parameterType="CardBoard" useGeneratedKeys="true" keyProperty="cardBoardId">
         INSERT INTO cardboard (cardboard_id, user_id, card_ids)
         VALUES (#{cardBoardId}, #{userId}, #{cardIds, typeHandler=org.wedding.adapter.out.persistence.mybatis.JsonTypeHandler})
     </insert>
 
     <select id="findCardBoardByUserId" parameterType="int" resultMap="CardBoardResultMap">
-        SELECT * FROM cardboard WHERE user_id = #{userId}
+        SELECT cardboard_id, user_id, card_ids FROM cardboard WHERE user_id = #{userId}
+    </select>
+
+    <select id="findCardIdsByUserId" parameterType="int" resultMap="CardIdsResultMap">
+        SELECT card_ids FROM cardboard WHERE user_id = #{userId}
     </select>
 </mapper>

--- a/src/test/java/org/wedding/adapter/in/web/ReadCardBoardIntegTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/ReadCardBoardIntegTest.java
@@ -1,0 +1,61 @@
+package org.wedding.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+import org.wedding.common.security.JwtUtils;
+import org.wedding.domain.CardStatus;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ReadCardBoardIntegTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        int userId = 0; // 테스트용 사용자 ID
+        token = JwtUtils.generateToken(userId);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken (
+            userId, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    void readCardsByStatus() throws Exception {
+        // given
+        CardStatus cardStatus = CardStatus.BACKLOG;
+
+        // when
+        MockHttpServletRequestBuilder request =
+            get("/api/v1/cardboard/{cardStatus}", cardStatus)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token);
+
+        // then
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[0].cardId").isNumber())
+            .andExpect(jsonPath("$[0].cardTitle").isString())
+            .andExpect(jsonPath("$[0].cardStatus").isString());
+    }
+}
+


### PR DESCRIPTION
### Isuue Number:
#75 

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 클라이언트에서 cardStatus를 받고 유저가 갖고 있는 카드 중 해당 상태의 카드를 반환함
- 클라이언트 요청/응답 컨트롤러와 서비스 계층간의 요청/응답, 그리고 서비스 간 데이터 전달 객체를 모드 분리하여 조회활 카드의 정보가 바뀌더라도 서비스 로직의 수정은 없도록 함

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- userId는 이전에 API에서 직접 request에 userId를 넣었다면, SecurityContext에 userId를 넣도록 리팩토링함
- mapper에서 cardIds를 리턴할 때 이중List로 리턴하여 한 번 더 데이터 처리함
- API 통합테스트 작성
## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.