### PR TITLE
[#77] 카드 생성시 카드보드에 신규 카드ID 저장하는 로직 구현

### DIFF
--- a/src/main/resources/mapper/CardBoardMapper.xml
+++ b/src/main/resources/mapper/CardBoardMapper.xml
@@ -26,4 +26,10 @@
     <select id="findCardIdsByUserId" parameterType="int" resultMap="CardIdsResultMap">
         SELECT card_ids FROM cardboard WHERE user_id = #{userId}
     </select>
+
+    <update id="addCardIds" parameterType="map">
+        UPDATE cardboard
+        SET card_ids = JSON_ARRAY_APPEND(card_ids, '$', #{cardId})
+        WHERE cardboard_id = #{cardBoardId}
+    </update>
 </mapper>

--- a/src/test/java/org/wedding/application/service/CardBoardServiceTest.java
+++ b/src/test/java/org/wedding/application/service/CardBoardServiceTest.java
@@ -1,0 +1,71 @@
+package org.wedding.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.wedding.application.port.out.repository.CardBoardRepository;
+import org.wedding.domain.cardboard.CardBoard;
+import org.wedding.domain.cardboard.exception.CardBoardError;
+import org.wedding.domain.cardboard.exception.CardBoardException;
+
+@ExtendWith(MockitoExtension.class)
+class CardBoardServiceTest {
+    @InjectMocks
+    private CardBoardService cardBoardUseCase;
+    @Mock
+    private CardBoardRepository cardBoardRepository;
+    private CardBoard cardBoard;
+    private int userId;
+    private int cardId;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1;
+        cardId = 100;
+        List<Integer> cardIds = new ArrayList<>(Arrays.asList(1, 2, 3));
+        cardBoard = new CardBoard(1, userId, cardIds);
+    }
+
+    @DisplayName("카드 저장시 카드보드에 신규 카드ID가 추가된다")
+    @Test
+    void addCardToCardBoard_Success() {
+        // given
+        when(cardBoardRepository.findCardBoardByUserId(userId)).thenReturn(cardBoard);
+
+        // when
+        cardBoardUseCase.addCardToCardBoard(cardId, userId);
+
+        // then
+        verify(cardBoardRepository, times(1)).findCardBoardByUserId(userId);
+        verify(cardBoardRepository, times(1)).addCardIds(cardBoard.getCardBoardId(), cardId);
+        assertEquals(4, cardBoard.getCardIds().size());
+        assertEquals(1, cardBoard.getUserId());
+        assertEquals(Arrays.asList(1, 2, 3, 100), Arrays.stream(cardBoard.getCardIds().toArray()).toList());
+        // 신규 카드ID가 인덱스 마지막에 추가된다
+        assertEquals(cardBoard.getCardIds().lastIndexOf(cardId), cardBoard.getCardIds().size() - 1);
+    }
+
+    @DisplayName("카드 저장시 카드보드가 없으면 예외를 발생시킨다")
+    @Test
+    void addCardToCardBoard_CardBoardNotFound() {
+        when(cardBoardRepository.findCardBoardByUserId(userId)).thenReturn(null);
+
+        CardBoardException exception = assertThrows(CardBoardException.class,
+            () -> cardBoardUseCase.addCardToCardBoard(cardId, userId));
+
+        assertEquals(CardBoardError.CARD_BOARD_NOT_FOUND, exception.getCardBoardError());
+        verify(cardBoardRepository, times(1)).findCardBoardByUserId(userId);
+        verify(cardBoardRepository, never()).addCardIds(anyInt(), anyInt());
+    }
+}


### PR DESCRIPTION
### Isuue Number:
#77 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 카드ID를 추가하는 쿼리를 구현한다.
- 신규 카드ID는 카드ID 리스트의 마지막 인덱스에 추가된다.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.