### PR TITLE
[#80] 카드 수정시 카드보드의 카드 소유주 검사 선 진행하도록 로직 리팩토링

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -61,8 +61,8 @@ public class CardController {
     public ResponseEntity<ApiResponse<Void>> modifyCard(
         @PathVariable int cardId,
         @RequestBody @Valid ModifyCardRequest request) {
-
-        ModifyCardCommand command = new ModifyCardCommand(request.cardTitle(), request.budget(), request.deadline(), request.cardStatus());
+        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        ModifyCardCommand command = new ModifyCardCommand(userId, request.cardTitle(), request.budget(), request.deadline(), request.cardStatus());
 
         modifyCardUseCase.modifyCard(cardId, command);
 

--- a/src/main/java/org/wedding/application/port/in/command/card/ModifyCardCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/card/ModifyCardCommand.java
@@ -10,24 +10,26 @@ import lombok.Builder;
 @Builder
 public record ModifyCardCommand(
 
+    int userId,
     Optional<String> cardTitle,
     Optional<Long> budget,
     Optional<LocalDate> deadline,
     Optional<CardStatus> cardStatus
 ) {
 
-        public ModifyCardCommand(String cardTitle, Long budget, LocalDate deadline, CardStatus cardStatus) {
-            this(Optional.ofNullable(cardTitle), Optional.ofNullable(budget), Optional.ofNullable(deadline), Optional.ofNullable(cardStatus));
+        public ModifyCardCommand(int userId, String cardTitle, Long budget, LocalDate deadline, CardStatus cardStatus) {
+            this(userId, Optional.ofNullable(cardTitle), Optional.ofNullable(budget), Optional.ofNullable(deadline), Optional.ofNullable(cardStatus));
         }
 
         public String toString() {
             return """
                 ModifyCardCommand{
+                    userId='%s',
                     cardTitle='%s',
                     budget='%s',
                     deadline='%s',
                     cardStatus='%s'
                 }
-                """.formatted(cardTitle, budget, deadline, cardStatus);
+                """.formatted(userId, cardTitle, budget, deadline, cardStatus);
         }
 }

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.wedding.application.port.in.CardBoardUseCase;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
@@ -28,6 +29,7 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase, ReadCa
 
     private final CardRepository cardRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final CardBoardUseCase cardBoardUseCase;
 
     @Transactional
     @Override
@@ -44,7 +46,9 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase, ReadCa
     @Override
     public void modifyCard(int cardId, ModifyCardCommand command) {
 
-        checkCardExistence(cardId);
+        if (!cardBoardUseCase.checkCardOwner(command.userId(), cardId)) {
+            throw new CardException(CardError.CARD_OWNER_NOT_MATCH);
+        }
         Card card = cardRepository.findByCardId(cardId);
 
         if (command.cardTitle().isPresent()) {

--- a/src/main/java/org/wedding/domain/card/exception/CardError.java
+++ b/src/main/java/org/wedding/domain/card/exception/CardError.java
@@ -23,7 +23,8 @@ public enum CardError implements CommonError {
     CARD_NOT_UPDATED(HttpStatus.INTERNAL_SERVER_ERROR, "카드 수정에 실패했습니다."),
     CARD_NOT_DELETED(HttpStatus.INTERNAL_SERVER_ERROR, "카드 삭제에 실패했습니다."),
     CARD_NOT_MOVED_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "카드 상태 변경에 실패했습니다."),
-    BUDGET_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "예산은 0 이상으로 입력해주세요.")
+    BUDGET_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "예산은 0 이상으로 입력해주세요."),
+    CARD_OWNER_NOT_MATCH(HttpStatus.FORBIDDEN, "카드 소유자가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### Isuue Number:
#80 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

기존 카드는 카드ID가 존재하는지만 판단하여 user가 해당 card를 가지고 있는지는 검증할 수 없었다.
카드보드의 카드 소유주 검사를 진행하면 카드ID 존재 여부와 user가 card를 갖고있는지 함께 검증할 수 있어서
기존 검증 로직은 제거하고 카드 소유주 검사를 진행하도록 했다.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.