### PR TITLE
[#83] 카드 수정시 카드보드가 카드에게 수정을 요청하는 꼴로 설계 수정

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.wedding.adapter.out.dto.CardsResponse;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
 import org.wedding.application.service.response.cardboard.CardInfo;
 import org.wedding.domain.CardStatus;

--- a/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
@@ -7,18 +7,25 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.adapter.out.dto.CardsResponse;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
+import org.wedding.application.port.in.usecase.cardboard.RequestCardUseCase;
 import org.wedding.application.service.response.cardboard.CardInfo;
+import org.wedding.common.response.ApiResponse;
 import org.wedding.domain.CardStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CardBoardController {
 
     private final CardBoardUseCase cardBoardUseCase;
+    private final RequestCardUseCase requestCardUseCase;
 
     @GetMapping("/{cardStatus}")
     @Operation(summary = "카드 상태별 조회" , description = "카드 상태별 조회")
@@ -51,5 +59,20 @@ public class CardBoardController {
                 ));
         }
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PatchMapping("{cardId}")
+    @Operation(summary = "카드 수정", description = "카드보드가 카드에게 수정을 요청한다.")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<Void>> modifyCard(
+        @PathVariable int cardId,
+        @RequestBody @Valid ModifyCardRequest request) {
+        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        ModifyCardCommand command = new ModifyCardCommand(userId, request.cardTitle(), request.budget(), request.deadline(), request.cardStatus());
+
+        requestCardUseCase.requestModifyCard(cardId, command);
+
+        ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 수정되었습니다.");
+        return new ResponseEntity<>(response, response.status());
     }
 }

--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,12 +12,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.wedding.adapter.in.web.dto.CreateCardRequest;
-import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
-import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
 import org.wedding.application.port.in.usecase.card.DeleteCardUseCase;
-import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.in.usecase.card.ReadCardUseCase;
 import org.wedding.application.service.response.card.ReadCardResponse;
 import org.wedding.common.response.ApiResponse;
@@ -37,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 public class CardController {
 
     private final CreateCardUseCase createCardUseCase;
-    private final ModifyCardUseCase modifyCardUseCase;
     private final ReadCardUseCase   readCardUseCase;
     private final DeleteCardUseCase deleteCardUseCase;
 
@@ -52,21 +47,6 @@ public class CardController {
         createCardUseCase.createCard(command);
 
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.CREATED, "카드가 생성되었습니다.");
-        return new ResponseEntity<>(response, response.status());
-    }
-
-    @PatchMapping("/{cardId}")
-    @Operation(summary = "카드 수정", description = "카드 수정")
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<Void>> modifyCard(
-        @PathVariable int cardId,
-        @RequestBody @Valid ModifyCardRequest request) {
-        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        ModifyCardCommand command = new ModifyCardCommand(userId, request.cardTitle(), request.budget(), request.deadline(), request.cardStatus());
-
-        modifyCardUseCase.modifyCard(cardId, command);
-
-        ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 수정되었습니다.");
         return new ResponseEntity<>(response, response.status());
     }
 

--- a/src/main/java/org/wedding/adapter/in/web/event/CardCreatedEventListener.java
+++ b/src/main/java/org/wedding/adapter/in/web/event/CardCreatedEventListener.java
@@ -2,7 +2,7 @@ package org.wedding.adapter.in.web.event;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.domain.card.event.CardCreatedEvent;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/wedding/adapter/in/web/event/UserCreatedEventListener.java
+++ b/src/main/java/org/wedding/adapter/in/web/event/UserCreatedEventListener.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
 import org.wedding.domain.user.event.UserCreatedEvent;
 

--- a/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardBoardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardBoardUseCase.java
@@ -10,5 +10,4 @@ public interface CardBoardUseCase {
     void createCardBoard(CreateCardBoardCommand command);
     void addCardToCardBoard(int cardId, int userId);
     List<CardInfo> readCardsByStatus(ReadCardCommand command);
-    boolean checkCardOwner(int userId, int cardId);
 }

--- a/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardBoardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardBoardUseCase.java
@@ -1,4 +1,4 @@
-package org.wedding.application.port.in;
+package org.wedding.application.port.in.usecase.cardboard;
 
 import java.util.List;
 

--- a/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardOwnerShipValidator.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/cardboard/CardOwnerShipValidator.java
@@ -1,0 +1,5 @@
+package org.wedding.application.port.in.usecase.cardboard;
+
+public interface CardOwnerShipValidator {
+    boolean checkCardOwner(int userId, int cardId);
+}

--- a/src/main/java/org/wedding/application/port/in/usecase/cardboard/RequestCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/cardboard/RequestCardUseCase.java
@@ -1,0 +1,8 @@
+package org.wedding.application.port.in.usecase.cardboard;
+
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
+
+public interface RequestCardUseCase {
+
+    void requestModifyCard(int cardId, ModifyCardCommand command);
+}

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
 import org.wedding.application.port.in.usecase.card.ReadCardUseCase;

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -13,6 +13,7 @@ import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
 import org.wedding.application.port.in.usecase.card.ReadCardUseCase;
 import org.wedding.application.port.in.usecase.cardboard.CardOwnerShipValidator;
+import org.wedding.application.port.in.usecase.cardboard.RequestCardUseCase;
 import org.wedding.application.port.out.repository.CardBoardRepository;
 import org.wedding.application.service.response.card.ReadCardResponse;
 import org.wedding.application.service.response.cardboard.CardInfo;
@@ -27,7 +28,7 @@ import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
-public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidator {
+public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidator, RequestCardUseCase {
 
     private final CardBoardRepository cardBoardRepository;
     private final ReadCardUseCase readCardUseCase;
@@ -63,7 +64,8 @@ public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidato
     }
 
     @Transactional
-    public void modifyCard(int cardId, ModifyCardCommand command) {
+    @Override
+    public void requestModifyCard(int cardId, ModifyCardCommand command) {
         if(!checkCardOwner(command.userId(), cardId)) {
             throw new CardBoardException(CardBoardError.CARD_OWNER_NOT_MATCH);
         }

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.wedding.application.port.in.command.card.ModifyCardCommand;
+import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
@@ -29,6 +31,7 @@ public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidato
 
     private final CardBoardRepository cardBoardRepository;
     private final ReadCardUseCase readCardUseCase;
+    private final ModifyCardUseCase modifyCardUseCase;
 
     @Override
     public void createCardBoard(CreateCardBoardCommand command) {
@@ -57,6 +60,14 @@ public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidato
         List<ReadCardResponse> cardResponses =
             readCardUseCase.readCardsStausByIdsAndStatus(cardIds, command.cardStatus());
         return toCardBoardCardInfo(cardResponses);
+    }
+
+    @Transactional
+    public void modifyCard(int cardId, ModifyCardCommand command) {
+        if(!checkCardOwner(command.userId(), cardId)) {
+            throw new CardBoardException(CardBoardError.CARD_OWNER_NOT_MATCH);
+        }
+        modifyCardUseCase.modifyCard(cardId, command);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -10,6 +10,7 @@ import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
 import org.wedding.application.port.in.usecase.card.ReadCardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardOwnerShipValidator;
 import org.wedding.application.port.out.repository.CardBoardRepository;
 import org.wedding.application.service.response.card.ReadCardResponse;
 import org.wedding.application.service.response.cardboard.CardInfo;
@@ -24,7 +25,7 @@ import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
-public class CardBoardService implements CardBoardUseCase {
+public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidator {
 
     private final CardBoardRepository cardBoardRepository;
     private final ReadCardUseCase readCardUseCase;

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -1,5 +1,7 @@
 package org.wedding.application.service;
 
+import static org.springframework.transaction.annotation.Propagation.*;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,7 +42,7 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase, ReadCa
         eventPublisher.publishEvent(new CardCreatedEvent(card.getCardId(), command.userId()));
     }
 
-    @Transactional
+    @Transactional(propagation = MANDATORY)
     @Override
     public void modifyCard(int cardId, ModifyCardCommand command) {
         Card card = cardRepository.findByCardId(cardId);

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;

--- a/src/main/java/org/wedding/application/service/CardService.java
+++ b/src/main/java/org/wedding/application/service/CardService.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.card.CreateCardUseCase;
@@ -29,7 +28,6 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase, ReadCa
 
     private final CardRepository cardRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final CardBoardUseCase cardBoardUseCase;
 
     @Transactional
     @Override
@@ -45,10 +43,6 @@ public class CardService implements CreateCardUseCase, ModifyCardUseCase, ReadCa
     @Transactional
     @Override
     public void modifyCard(int cardId, ModifyCardCommand command) {
-
-        if (!cardBoardUseCase.checkCardOwner(command.userId(), cardId)) {
-            throw new CardException(CardError.CARD_OWNER_NOT_MATCH);
-        }
         Card card = cardRepository.findByCardId(cardId);
 
         if (command.cardTitle().isPresent()) {

--- a/src/main/java/org/wedding/domain/card/exception/CardError.java
+++ b/src/main/java/org/wedding/domain/card/exception/CardError.java
@@ -23,8 +23,7 @@ public enum CardError implements CommonError {
     CARD_NOT_UPDATED(HttpStatus.INTERNAL_SERVER_ERROR, "카드 수정에 실패했습니다."),
     CARD_NOT_DELETED(HttpStatus.INTERNAL_SERVER_ERROR, "카드 삭제에 실패했습니다."),
     CARD_NOT_MOVED_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "카드 상태 변경에 실패했습니다."),
-    BUDGET_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "예산은 0 이상으로 입력해주세요."),
-    CARD_OWNER_NOT_MATCH(HttpStatus.FORBIDDEN, "카드 소유자가 일치하지 않습니다.")
+    BUDGET_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "예산은 0 이상으로 입력해주세요.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/wedding/domain/cardboard/exception/CardBoardError.java
+++ b/src/main/java/org/wedding/domain/cardboard/exception/CardBoardError.java
@@ -14,7 +14,9 @@ public enum CardBoardError implements CommonError {
 
     CARD_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카드보드를 찾을 수 없습니다."),
     CARD_NOT_SAVE(HttpStatus.INTERNAL_SERVER_ERROR, "카드 저장에 실패했습니다."),
-    CARD_NOT_LOAD(HttpStatus.INTERNAL_SERVER_ERROR, "카드 불러오기에 실패했습니다.");
+    CARD_NOT_LOAD(HttpStatus.INTERNAL_SERVER_ERROR, "카드 불러오기에 실패했습니다."),
+    CARD_OWNER_NOT_MATCH(HttpStatus.FORBIDDEN, "카드 소유자가 일치하지 않습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
@@ -1,0 +1,72 @@
+package org.wedding.adapter.in.web;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.wedding.adapter.in.web.dto.ModifyCardRequest;
+import org.wedding.common.security.JwtUtils;
+import org.wedding.domain.CardStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ModifyCardIntegTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        int userId = 0; // 테스트용 사용자 ID
+        token = JwtUtils.generateToken(userId);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken (
+            userId, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @DisplayName("카드 수정")
+    @Test
+    void modifyCard() throws Exception {
+        // given
+        int cardId = 0; // 테스트용 카드 ID
+        CardStatus modifyStatus = CardStatus.DONE;
+        ModifyCardRequest modifyCardRequest = ModifyCardRequest.builder()
+                .cardTitle(Optional.of("카드 제목 수정"))
+                .budget(Optional.of(10000L))
+                .cardStatus(Optional.of(modifyStatus))
+                .build();
+
+        String request = objectMapper.writeValueAsString(modifyCardRequest);
+
+        // when
+        ResultActions resultActions =
+            mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/cardboard/{cardId}", cardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(request));
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("카드가 수정되었습니다."));
+    }
+}

--- a/src/test/java/org/wedding/application/service/CardServiceTest.java
+++ b/src/test/java/org/wedding/application/service/CardServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.wedding.application.port.in.CardBoardUseCase;
+import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.out.repository.CardRepository;

--- a/src/test/java/org/wedding/application/service/CardServiceTest.java
+++ b/src/test/java/org/wedding/application/service/CardServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.card.CreateCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.out.repository.CardRepository;
@@ -38,8 +37,6 @@ class CardServiceTest {
     private CardRepository cardRepository;
     @Mock
     private ApplicationEventPublisher eventPublisher;
-    @Mock
-    private CardBoardUseCase cardBoardUseCase;
 
     private Card card;
     private CreateCardCommand createCommand;
@@ -55,7 +52,7 @@ class CardServiceTest {
             null
         );
 
-        cardService = new CardService(cardRepository, eventPublisher, cardBoardUseCase);
+        cardService = new CardService(cardRepository, eventPublisher);
         card = CreateCardCommand.toEntity(createCommand);
 
         cards = Arrays.asList(
@@ -140,7 +137,6 @@ class CardServiceTest {
         lenient().when(cardRepository.existsByCardId(card.getCardId())).thenReturn(true);
         lenient().when(cardRepository.existsByCardTitle(modifyCardTitleCommand.cardTitle().get())).thenReturn(false);
         lenient().when(cardRepository.findByCardId(card.getCardId())).thenReturn(card);
-        when(cardBoardUseCase.checkCardOwner(userId, card.getCardId())).thenReturn(true);
         cardService.modifyCard(card.getCardId(), modifyCardTitleCommand);
         verify(cardRepository, times(1)).update(any());
     }
@@ -155,7 +151,6 @@ class CardServiceTest {
             null,
             null
         );
-        when(cardBoardUseCase.checkCardOwner(userId, card.getCardId())).thenReturn(false);
 
         assertThrows(CardException.class, () -> cardService.modifyCard(card.getCardId(), modifyCardTitleCommand));
     }
@@ -175,7 +170,6 @@ class CardServiceTest {
         lenient().when(cardRepository.existsByCardId(card.getCardId())).thenReturn(true);
         assertThat(modifyCardStatusCommand.cardTitle()).isEqualTo(Optional.empty());
         lenient().when(cardRepository.findByCardId(card.getCardId())).thenReturn(card);
-        when(cardBoardUseCase.checkCardOwner(userId, card.getCardId())).thenReturn(true);
         cardService.modifyCard(card.getCardId(), modifyCardStatusCommand);
         verify(cardRepository, times(1)).update(any());
     }


### PR DESCRIPTION
### Isuue Number:
#83 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 카드보드의 역할에 대한 고민 후 도출함

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 단순, 유저와 카드 정보를 맵핑하는 역할이 아닌 유저의 요청대로 카드를 관리하는 역할을 부여함.
- 가령 유저가 투두 카드가 붙여진 화이트보드에 수정을 요청하면 화이트보드가 직접 카드를 때서 카드에게 유저의 요청을 전달하고 다시 필요한 위치에 붙임(도메인 의인화)
  - 카드에게 요청을 전달하는 기능을 `RequestCard` 인터페이스로 추상화함.
- 카드보드의 역할로 유저와 카드는 서로를 모름.
- 카드의 서비스 로직은 고유함. 주처젝인 객체로서 존재할 수 있음.

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.